### PR TITLE
fix: Add cors headers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,12 +68,14 @@ func main() {
 			"dateJoined":  dateJoined,
 			"nbf":         time.Date(2015, 10, 10, 12, 0, 0, 0, time.UTC).Unix(),
 		})
+
 		tokenString, err := token.SignedString([]byte("potatosecret"))
 		if err != nil {
 			http.Error(w, "Error generating JWT: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"token": "%s"}`, tokenString)
 	})

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for auth-lingering-breeze-695 on 2024-11-09T23:35:17-05:00
+# fly.toml app configuration file generated for website-base-auth on 2024-11-23T12:25:54-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
@@ -7,8 +7,6 @@ app = 'website-base-auth'
 primary_region = 'ewr'
 
 [build]
-  [build.args]
-    GO_VERSION = '1.21.0'
 
 [env]
   PORT = '8080'


### PR DESCRIPTION
References https://github.com/dearborn-coding-club/website-base-auth/issues/5

## Summary
Introduces the CORS header to all requests so that it can be used in consort with the front-end.