### PR TITLE
fix: Update register query

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,7 +125,7 @@ func main() {
 			return
 		}
 
-		rows, err := db.Query("SELECT * FROM AUTH_USER WHERE USERNAME = $1", registerRequest.Username)
+		rows, err := db.Query("SELECT * FROM ACCOUNTS_DCCUSER WHERE USERNAME = $1", registerRequest.Username)
 
 		if err != nil {
 			http.Error(w, "Error selecting from database: "+err.Error(), http.StatusInternalServerError)
@@ -137,7 +137,7 @@ func main() {
 			return
 		}
 
-		_, err = db.Exec("INSERT INTO AUTH_USER (password, username, email, is_superuser, first_name, last_name, is_staff, is_active, date_joined) VALUES ($1, $2, $3, FALSE, 'test_name', 'test_name', FALSE, FALSE, '2017-03-14')", registerRequest.Username, registerRequest.Password, registerRequest.Email)
+		_, err = db.Exec("INSERT INTO ACCOUNTS_DCCUSER (password, username, email, is_superuser, first_name, last_name, is_staff, is_active, date_joined, bio, birthdate, profile_id, last_login) VALUES ($1, $2, $3, FALSE, 'test_name', 'test_name', FALSE, FALSE, '2017-03-14', 'test-bio', '2017-03-14', 1, '2017-03-14')", registerRequest.Username, registerRequest.Password, registerRequest.Email)
 
 		if err != nil {
 			http.Error(w, "Error querying the database: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
- Updates auth `/register` endpoint to use the `ACCOUNTS_DCCUSER` table instead of `AUTH_USER`.
- Updates insert query to have adequate default values so the insertion doesn't fail.

## Context
We want to fix our register endpoint so users can start to sign up successfully. It's currently failing because insertion query doesn't contain the right defaults. 