### PR TITLE
fix: Return valid json

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -145,7 +145,8 @@ func main() {
 		}
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "{ 'generated': true }")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{ "generated": true }`)
 	})
 
 	// Handler function for the root path ("/")


### PR DESCRIPTION
## Summary
- Return valid JSON with correct `"` double quotes from `/register` endpoint.