### PR TITLE
docs: Introduce pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+Closes <Related issue>
+
+## Summary
+- <Bulleted list of what the PR does>
+
+## Context
+- <Relevant backstory for understanding the purpose of this PR>
+
+## Screenshots
+- <If applicable, attach screenshots of the changes.>


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-auth/issues/33

## Context
We're missing a pull request template in this repo. This PR introduces here, using the [front end repo](https://github.com/dearborn-coding-club/website-base-frontend) as a guide.

## Summary
- Introduces a pull request template to this repository.